### PR TITLE
remove bintray link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Heroku sbt Plugin [![Build Status](https://travis-ci.com/heroku/sbt-heroku.svg?branch=main)](https://travis-ci.com/heroku/sbt-heroku) [![Download](https://api.bintray.com/packages/heroku/sbt-plugins/sbt-heroku/images/download.svg) ](https://bintray.com/heroku/sbt-plugins/sbt-heroku/_latestVersion)
+Heroku sbt Plugin [![Build Status](https://travis-ci.com/heroku/sbt-heroku.svg?branch=main)](https://travis-ci.com/heroku/sbt-heroku)
 =================
 
 This plugin is used to deploy Scala and Play applications directly to Heroku without pushing to a Git repository.


### PR DESCRIPTION
I looked README in this repository, There is broken link of Bintray repository.
(Bintray service was sunset)