### PR TITLE
Remove Scala compiler from `libraryDependencies`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           version: 1.4.1
       - checkout
       - run: sbt "^publishLocal"
-      - run: sbt scripted
+      - run: sbt "^scripted"
 
 workflows:
   ci:

--- a/src/main/scala/com/heroku/sbt/HerokuPlugin.scala
+++ b/src/main/scala/com/heroku/sbt/HerokuPlugin.scala
@@ -73,7 +73,6 @@ object HerokuPlugin extends AutoPlugin {
   override val projectSettings: Seq[Setting[_]] =
     inConfig(Compile)(baseHerokuSettings) ++
     Seq(
-      libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "runtime",
       extraLoggers := {
         val currentFunction = extraLoggers.value
         val targetValue = target.value

--- a/src/sbt-test/scala3/akka-http/build.sbt
+++ b/src/sbt-test/scala3/akka-http/build.sbt
@@ -1,0 +1,57 @@
+name := "scala3-getting-started"
+
+version := "1.0"
+
+scalaVersion := "3.0.1"
+
+val AkkaVersion = "2.6.8"
+val AkkaHttpVersion = "10.2.6"
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
+).map(_.cross(CrossVersion.for3Use2_13))
+
+Compile / mainClass := Some("com.example.Server")
+
+Compile / herokuFatJar := Some((assembly / assemblyOutputPath).value)
+
+lazy val remoteAppName = "sbt-heroku-" + sys.props("heroku.uuid")
+Compile / herokuAppName := remoteAppName
+
+TaskKey[Unit]("createApp") := {
+  (packageBin in Compile).value
+  Process("heroku", Seq("apps:destroy", "-a", remoteAppName, "--confirm", remoteAppName)) ! streams.value.log
+  Process("heroku", Seq("create", "-n", remoteAppName)) ! streams.value.log
+}
+
+TaskKey[Unit]("cleanup") := {
+  (packageBin in Compile).value
+  Process("heroku", Seq("apps:destroy", "-a", remoteAppName, "--confirm", remoteAppName)) ! streams.value.log
+}
+
+TaskKey[Unit]("check") := {
+  (packageBin in Compile).value
+  var retries = 0
+  while (retries < 10) {
+    try {
+      val sb = new StringBuilder
+      for (line <- scala.io.Source.fromURL("https://" + remoteAppName + ".herokuapp.com/hello").getLines())
+        sb.append(line).append("\n")
+      val page = sb.toString()
+      if (!page.contains("Say hello to akka-http"))
+        sys.error("There is a problem with the webpage: " + page)
+      retries = 99999
+    } catch {
+      case ex: Exception =>
+        if (retries < 10) {
+          println("Error (retrying): " + ex.getMessage)
+          Thread.sleep(1000)
+          retries += 1
+        } else {
+          throw ex
+        }
+    }
+    ()
+  }
+}

--- a/src/sbt-test/scala3/akka-http/build.sbt
+++ b/src/sbt-test/scala3/akka-http/build.sbt
@@ -1,11 +1,13 @@
+import scala.sys.process._
+
 name := "scala3-getting-started"
 
 version := "1.0"
 
-scalaVersion := "3.0.1"
+scalaVersion := "3.1.2"
 
-val AkkaVersion = "2.6.8"
-val AkkaHttpVersion = "10.2.6"
+val AkkaVersion = "2.6.19"
+val AkkaHttpVersion = "10.2.9"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
@@ -20,18 +22,18 @@ lazy val remoteAppName = "sbt-heroku-" + sys.props("heroku.uuid")
 Compile / herokuAppName := remoteAppName
 
 TaskKey[Unit]("createApp") := {
-  (packageBin in Compile).value
+  (Compile / packageBin).value
   Process("heroku", Seq("apps:destroy", "-a", remoteAppName, "--confirm", remoteAppName)) ! streams.value.log
   Process("heroku", Seq("create", "-n", remoteAppName)) ! streams.value.log
 }
 
 TaskKey[Unit]("cleanup") := {
-  (packageBin in Compile).value
+  (Compile / packageBin).value
   Process("heroku", Seq("apps:destroy", "-a", remoteAppName, "--confirm", remoteAppName)) ! streams.value.log
 }
 
 TaskKey[Unit]("check") := {
-  (packageBin in Compile).value
+  (Compile / packageBin).value
   var retries = 0
   while (retries < 10) {
     try {

--- a/src/sbt-test/scala3/akka-http/project/build.properties
+++ b/src/sbt-test/scala3/akka-http/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5

--- a/src/sbt-test/scala3/akka-http/project/build.properties
+++ b/src/sbt-test/scala3/akka-http/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/src/sbt-test/scala3/akka-http/project/plugins.sbt
+++ b/src/sbt-test/scala3/akka-http/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.heroku" % "sbt-heroku" % sys.props("project.version"))
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")

--- a/src/sbt-test/scala3/akka-http/project/plugins.sbt
+++ b/src/sbt-test/scala3/akka-http/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.heroku" % "sbt-heroku" % sys.props("project.version"))
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")

--- a/src/sbt-test/scala3/akka-http/src/main/scala/com/example/Main.scala
+++ b/src/sbt-test/scala3/akka-http/src/main/scala/com/example/Main.scala
@@ -1,0 +1,31 @@
+package com.example
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import scala.io.StdIn
+
+object HttpServerRoutingMinimal {
+
+  def main(args: Array[String]): Unit = {
+
+    implicit val system = ActorSystem(Behaviors.empty, "my-system")
+    implicit val executionContext = system.executionContext
+
+    val route =
+      path("hello") {
+        get {
+          complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+        }
+      }
+
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
+
+    StdIn.readLine()
+    bindingFuture
+      .flatMap(_.unbind())
+      .onComplete(_ => system.terminate())
+  }
+}

--- a/src/sbt-test/scala3/akka-http/test
+++ b/src/sbt-test/scala3/akka-http/test
@@ -1,0 +1,13 @@
+# Stage the distribution and ensure it can be deployed.
+> compile
+> createApp
+> show assembly
+$ exists target/scala-3/scala3-getting-started-assembly-1.0.jar
+> show deployHeroku
+$ exists target/heroku/app/
+-$ exists target/heroku/app/.jdk/bin/java
+$ exists target/heroku/build.tgz
+-$ exists target/heroku/app/target/heroku/build.tgz
+$ exists target/heroku/diagnostics.log
+> check
+> cleanup


### PR DESCRIPTION
- I cannot use `sbt-heroku` in Scala 3 project due to this error:
    ```console
    [info] [error] sbt.librarymanagement.ResolveException: Error downloading org.scala-lang:scala-compiler:3.0.1
    [info] [error]   Not found
    [info] [error]   Not found
    [info] [error]   not found: /Users/yyu/.ivy2/local/org.scala-lang/scala-compiler/3.0.1/ivys/ivy.xml
    ```
- Actually I didn't know why `scala-compiler` had been added to `libraryDependencies` 🤔 
- I add Scala 3 + akka-http test
- Work around:
    - https://github.com/y-yu/kindle-clock/blob/4d0877076cd95bbe0d75046f0691327680fad908/build.sbt#L158-L163