### PR TITLE
Convert heroku/sbt-heroku to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: heroku/sbt-heroku/ci
+on:
+  push:
+env:
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+jobs:
+  sbt:
+    runs-on: sfdc-hk-ubuntu-latest
+    env:
+      executor: xxxxxxx
+    steps:
+    - shell: bash
+      run: |-
+        if [[ $(command -v heroku) == "" ]]; then
+          curl https://cli-assets.heroku.com/install.sh | sh
+        else
+          echo "Heroku is already installed. No operation was performed."
+        fi
+#     # This item has no matching transformer
+#     - joshdholtz_sdkman_setup_sdkman:
+#     # This item has no matching transformer
+#     - joshdholtz_sdkman_sdkman_install:
+    - uses: actions/checkout@v2
+    - run: sbt "^publishLocal"
+    - run: sbt scripted


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/sbt-heroku) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/sbt-heroku/ci
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest